### PR TITLE
FEAT: Add jackknife_corr as a compare option

### DIFF
--- a/docs/reference/_autosummary/hierarch.stats.rst
+++ b/docs/reference/_autosummary/hierarch.stats.rst
@@ -18,6 +18,7 @@
       confidence_interval
       hierarchical_randomization
       hypothesis_test
+      jackknife_studentized_covariance
       multi_sample_test
       studentized_covariance
       welch_statistic


### PR DESCRIPTION
## Summary

- Wires `jackknife_studentized_covariance` (added in #241) into the public API as `compare="jackknife_corr"` for both `hypothesis_test` and `confidence_interval`
- Creates `_jackknife_cov_std_error` to support test inversion in `confidence_interval`
- Updates `_compute_interval` to dispatch the correct SE function based on the compare type

## Test plan

- [x] `test_jackknife_corr_vs_corr` — exact test p-values match `"corr"`
- [x] `test_jackknife_corr_conf` — 95% CI wider than 68% CI
- [x] `TestJackknifeStdError.test_matches_naive` — closed-form SE matches naive leave-one-out
- [x] All existing tests still pass